### PR TITLE
changed the div id in include.js file to match the div id in index.html

### DIFF
--- a/js/include_footer.js
+++ b/js/include_footer.js
@@ -1,4 +1,4 @@
 
 			$(document).ready(function(){
-        		$("#div1").load("../dhamma_ui/html/footer.html");
+        		$("#footer").load("../dhamma_ui/html/footer.html");
 			});


### PR DESCRIPTION
To include another html inside the main html page, the div id in main html (index.html) should match the div id mentioned in the .js file (which contains the script to include the common html pages)